### PR TITLE
Add Facebook share button for the Zeron model.

### DIFF
--- a/carbon0/carbon0/settings.py
+++ b/carbon0/carbon0/settings.py
@@ -157,6 +157,9 @@ AWS_S3_FILE_OVERWRITE = False
 AWS_DEFAULT_ACL = None
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
+# Facebook variables 
+FACEBOOK_SHARING_APP_ID = os.getenv('FACEBOOK_SHARING_APP_ID')
+
 # Convert the DATABASE_URL environment variable into what Django understands
 db_from_env = dj_database_url.config()
 DATABASES['default'].update(db_from_env)

--- a/carbon0/carbon_quiz/templates/carbon_quiz/achievement/detail.html
+++ b/carbon0/carbon_quiz/templates/carbon_quiz/achievement/detail.html
@@ -28,12 +28,6 @@
                 <div class="col-md-4">
                     <!-- Image, Mission Complete Ribbon-->
                     <img src="{% static 'images/Present-_Mission_Completed.png' %}" alt="" width=300px height=300px>
-                   
-                    <!-- Facebook Share Button -->
-                    <div class="fb-share-button" data-href="https://mycarbon0.com" data-layout="button_count" data-size="large"><a
-                            target="_blank"
-                            href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fmycarbon0.com%2F&amp;src=sdkpreparse"
-                            class="fb-xfbml-parse-ignore">Share</a></div>
                 </div>
                 <div class="col-md-8">
                     <div class="row justify-content-center">
@@ -56,10 +50,21 @@
                         </div>
                 </div>
             </div>
-
-            <!-- Link to Sign Up -->
-            <div class="row justify-content-end">
-                <a class="btn btn-primary" href="{% url 'accounts:signup' %}">Sign Up for More</a>
+            <!-- Bottom Rows -->
+            <div class="row">
+                <p class="mr-auto">Like what you see?</p>
+            </div>
+            <div class="row">
+                <!-- Facebook Share Button -->
+                <div class="mr-auto">
+                    <div class="fb-share-button" data-href="https://mycarbon0.com" data-layout="button_count" data-size="large"><a
+                            target="_blank"
+                            href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fmycarbon0.com%2F&amp;src=sdkpreparse"
+                            class="fb-xfbml-parse-ignore">Share</a>
+                    </div>
+                </div>
+                <!-- Link to Sign Up -->
+                <a class="ml-auto btn btn-primary" href="{% url 'accounts:signup' %}">Sign Up for More</a>
             </div>
         </div>
     </div>

--- a/carbon0/carbon_quiz/templates/carbon_quiz/achievement/detail.html
+++ b/carbon0/carbon_quiz/templates/carbon_quiz/achievement/detail.html
@@ -1,6 +1,8 @@
 <!-- AchievementDetail template -->
 <!-- carbon0/carbon_quiz/templates/carbon_quiz/achievement/detail.html -->
 {% extends "base.html" %}
+<!-- Load static files, and page content below -->
+{% load static %}
 
 {% block metadata %}
     <!-- Facebook Open Graph Markup -->
@@ -10,11 +12,8 @@
     <meta property="fb:app_id" content="{{ app_id }}" />
     <meta property="og:title" content="Be a Hero, Get to Zero!" />
     <meta property="og:description" content="I'm committed to making a difference in the climate. Will you join me in the game to save the planet?" />
-    <meta property="og:image" content="{% static 'images/background_2.png' %}" />
+    <meta property="og:image" content="{% static 'images/background_2.png' %}" /> 
 {% endblock %}
-
-<!-- Load static files, and page content below -->
-{% load static %}
 
 {% block content %}
     <div style="background-color:rgb(255, 220, 176); height: 100vh;">
@@ -29,7 +28,12 @@
                 <div class="col-md-4">
                     <!-- Image, Mission Complete Ribbon-->
                     <img src="{% static 'images/Present-_Mission_Completed.png' %}" alt="" width=300px height=300px>
-                    <!-- Facebook Sharing -->
+                   
+                    <!-- Facebook Share Button -->
+                    <div class="fb-share-button" data-href="https://mycarbon0.com" data-layout="button_count" data-size="large"><a
+                            target="_blank"
+                            href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fmycarbon0.com%2F&amp;src=sdkpreparse"
+                            class="fb-xfbml-parse-ignore">Share</a></div>
                 </div>
                 <div class="col-md-8">
                     <div class="row justify-content-center">

--- a/carbon0/carbon_quiz/templates/carbon_quiz/achievement/detail.html
+++ b/carbon0/carbon_quiz/templates/carbon_quiz/achievement/detail.html
@@ -1,6 +1,19 @@
 <!-- AchievementDetail template -->
 <!-- carbon0/carbon_quiz/templates/carbon_quiz/achievement/detail.html -->
 {% extends "base.html" %}
+
+{% block metadata %}
+    <!-- Facebook Open Graph Markup -->
+    <meta property="og:url" content="https://www.mycarbon0.com" />
+    <meta property="og:type" content="threed.asset" />
+    <meta property="og:asset" content="{% static browser_model %}" />
+    <meta property="fb:app_id" content="{{ app_id }}" />
+    <meta property="og:title" content="Be a Hero, Get to Zero!" />
+    <meta property="og:description" content="I'm committed to making a difference in the climate. Will you join me in the game to save the planet?" />
+    <meta property="og:image" content="{% static 'images/background_2.png' %}" />
+{% endblock %}
+
+<!-- Load static files, and page content below -->
 {% load static %}
 
 {% block content %}
@@ -14,7 +27,9 @@
             <!-- Image, Mission Complete Ribbon-->
             <div class="row">
                 <div class="col-md-4">
+                    <!-- Image, Mission Complete Ribbon-->
                     <img src="{% static 'images/Present-_Mission_Completed.png' %}" alt="" width=300px height=300px>
+                    <!-- Facebook Sharing -->
                 </div>
                 <div class="col-md-8">
                     <div class="row justify-content-center">

--- a/carbon0/carbon_quiz/views.py
+++ b/carbon0/carbon_quiz/views.py
@@ -14,6 +14,7 @@ from .models.question import Question
 from .models.mission import Mission
 from .models.quiz import Quiz
 from .models.achievement import Achievement
+from django.conf import settings
 
 
 class QuizCreate(CreateView):
@@ -254,7 +255,8 @@ class AchievementDetail(DetailView):
         context = {
             'achievement': achievement,
             'browser_model': browser_zeron_model,
-            'ios_model': ios_zeron_model
+            'ios_model': ios_zeron_model,
+            'app_id': settings.FACEBOOK_SHARING_APP_ID
         }
         # return the response
         return render(request, self.template_name, context)

--- a/carbon0/templates/base.html
+++ b/carbon0/templates/base.html
@@ -31,6 +31,8 @@
         ga('create', 'UA-XXXXX-Y', 'auto');
         ga('send', 'pageview');
     </script>
+    <!-- Additional Meta Data Goes Here -->
+    {% block metadata %}{% endblock %}
 </head>
 <body>
     <!-- TODO: Add Navbar -->

--- a/carbon0/templates/base.html
+++ b/carbon0/templates/base.html
@@ -35,7 +35,11 @@
     {% block metadata %}{% endblock %}
 </head>
 <body>
-    <!-- TODO: Add Navbar -->
+    <!-- Facebook Javascript SDK -->
+    <div id="fb-root"></div>
+    <script async defer crossorigin="anonymous"
+        src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v8.0&appId=601522010515607&autoLogAppEvents=1"
+        nonce="EPSGDahf"></script>
 
     <!-- Template Block: Main Body -->
     {% block content %}


### PR DESCRIPTION
**Known issues:**

1. **App ID** I have not yet been able to get Carbon0's Facebook credentials to be able to make an app for this feature. So at some point when I do get their Facebook credentials, we will need to make a new app on their account, and use that `app_id` for this feature instead.

2. **Share Preview**: Currently the Zeron model does not show in the pop up window, but I believe that in the dev environment the site uses the URL of the Zeron model that's on the local filesystem, instead of what we have stored on AWS. So perhaps we should just ship this feature, and see if when in production it actually shows the model?

To better explain, here is the code in the `AchievementDetail` template that controls the markup of the Facebook Share: 

```
<meta property="og:asset" content="{% static browser_model %}" />
```
And when running on `localhost`, the `{% static browser_model %}` resolves to `/static/assets/usdz-files/coin.usdz`, for example.


**Resources I Looked At**
1. [Facebook Share Docs - Home Page](https://developers.facebook.com/docs/plugins/share-button/)
2. [Facebook Share Open Graph Markup](https://developers.facebook.com/docs/sharing/webmasters#markup) 
3. [Sharing 3D models using Facebook](https://developers.facebook.com/docs/sharing/3d-posts/open-graph-sharing)
4. [Facebook Share Button Configurator](https://developers.facebook.com/docs/plugins/share-button/#)